### PR TITLE
Fix/ci release npm via node24

### DIFF
--- a/.changeset/dark-pandas-film.md
+++ b/.changeset/dark-pandas-film.md
@@ -1,0 +1,6 @@
+---
+"@fabric-space/fabric-ajv": patch
+"@fabric-space/fabric-async": patch
+---
+
+Use Node 24 in GitHub Actions workflows for trusted publishing compatibility.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
-
-      - name: Upgrade npm
-        run: npm install -g npm@^11.5.1
 
       - name: Install Dependencies
         run: npm ci  --ignore-scripts

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,11 +23,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
-
-      - name: Upgrade npm
-        run: npm install -g npm@^11.5.1
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Upgrade npm
-        run: npm install -g npm@^11.5.1
 
       - name: Install Dependencies
         run: npm ci  --ignore-scripts


### PR DESCRIPTION
Use Node 24 in GitHub Actions workflows for trusted publishing compatibility.